### PR TITLE
Allow custom buffer decoders, fix issue #12 

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ A pure javascript library to connect to a Vertica database. Except that it is wr
 
 ### Connecting
 
-Call the `connect` method with a connection options object. The following connection 
+Call the `connect` method with a connection options object. The following connection
 options are supported.
 
 - `host`: the host to connect to (default: `"localhost"`)
@@ -23,13 +23,14 @@ options are supported.
     - `false`: no SSL
     - `"optional"`: use SSL if the server supports it, but fall back to no SSL if not (default).
     - `"required"`: use SSL, throw an error if the server doesn't support it.
-    - `"verified"`: use SSL, throw an error if the server doesn't support it or its SSL 
+    - `"verified"`: use SSL, throw an error if the server doesn't support it or its SSL
       certificate could not be verified.
 - `role`: Runs a `SET ROLE` query to activate a role for the user immediately after connecting.
-- `searchPath`: Runs a `SET SEARCH_PATH TO` query to set the search path after connecting. 
+- `searchPath`: Runs a `SET SEARCH_PATH TO` query to set the search path after connecting.
 - `timezone`: Runs a `SET TIMEZONE TO` query to set the connection's time zone after connecting.
-- `initializer`: a callback function that gets called after connection but before any query 
+- `initializer`: a callback function that gets called after connection but before any query
   gets executed.
+- `decoders`: an object containing custom buffer decoders for query result field deserialization, see usage in custom decoders test.
 
 ```coffeescript
 
@@ -40,17 +41,17 @@ connection = Vertica.connect host: 'localhost', user: "me", password: 'secret', 
 
 *Note:* the `connect` will establish a single connection. A connection can only execute
 one query at the time. Due to the evented nature of node.js, it is possible to start a new
-query while another query is still running. This library implements a simple queueing 
+query while another query is still running. This library implements a simple queueing
 system that will run queries serially.
 
 If you want parallelism, you will need multiple connections to your server. You can set up
 connection pooling fairly easily using the `generic-pool` library. Note that transactions
-cannot be shared between multiple connections; you need to use the same connection for all 
+cannot be shared between multiple connections; you need to use the same connection for all
 queries in the transaction and run them in serial.
 
 ### Querying (buffered)
 
-Running a buffered query will assemble the result in memory and call the callback 
+Running a buffered query will assemble the result in memory and call the callback
 function when it is completed.
 
 ```coffeescript
@@ -66,7 +67,7 @@ query.callback = (err, resultset) -> ...
 ```
 
 ### Querying (unbuffered)
- 
+
 Running an unbuffered query will immediately emit incoming data as events and
 will not store the result in memory. Recommended for handling huge resultsets.
 

--- a/lib/query.js
+++ b/lib/query.js
@@ -51,7 +51,7 @@ Query = (function(_super) {
     _ref = msg.columns;
     for (_i = 0, _len = _ref.length; _i < _len; _i++) {
       column = _ref[_i];
-      field = new Query.Field(column);
+      field = new Query.Field(column, this.connection.connectionOptions.decoders);
       this.emit('field', field);
       this.fields.push(field);
     }
@@ -218,7 +218,9 @@ Query = (function(_super) {
 })(EventEmitter);
 
 Query.Field = (function() {
-  function Field(msg) {
+  function Field(msg, customDecoders) {
+    var decoder;
+
     this.name = msg.name;
     this.tableOID = msg.tableOID;
     this.tableFieldIndex = msg.tableFieldIndex;
@@ -227,7 +229,10 @@ Query.Field = (function() {
     this.size = msg.size;
     this.modifier = msg.modifier;
     this.formatCode = msg.formatCode;
-    this.decoder = decoders[this.formatCode][this.type] || decoders[this.formatCode]["default"];
+    if (customDecoders) {
+      decoder = customDecoders[this.type] || customDecoders["default"];
+    }
+    this.decoder = decoder || decoders[this.formatCode][this.type] || decoders[this.formatCode]["default"];
   }
 
   return Field;

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     {
       "name": "Willem van Bergen",
       "email": "willem@railsdoctors.com",
-      "web": "http://www.vanbergen.org" 
+      "web": "http://www.vanbergen.org"
     }
   ],
   "devDependencies": {

--- a/src/query.coffee
+++ b/src/query.coffee
@@ -33,7 +33,7 @@ class Query extends EventEmitter
 
     @fields = []
     for column in msg.columns
-      field = new Query.Field(column)
+      field = new Query.Field(column, @connection.connectionOptions.decoders)
       @emit 'field', field
       @fields.push field
 
@@ -141,7 +141,7 @@ class Query extends EventEmitter
     @connection.removeListener 'CopyInResponse',     @onCopyInResponseListener
 
 class Query.Field
-  constructor: (msg) ->
+  constructor: (msg, customDecoders) ->
     @name            = msg.name
     @tableOID        = msg.tableOID
     @tableFieldIndex = msg.tableFieldIndex
@@ -151,7 +151,11 @@ class Query.Field
     @modifier        = msg.modifier
     @formatCode      = msg.formatCode
 
-    @decoder = decoders[@formatCode][@type] || decoders[@formatCode].default
+    if customDecoders
+      # custom decoders have precedence
+      decoder = customDecoders[@type] || customDecoders.default
+
+    @decoder = decoder || decoders[@formatCode][@type] || decoders[@formatCode].default
 
 
 module.exports = Query

--- a/test/custom_decoders_test.coffee
+++ b/test/custom_decoders_test.coffee
@@ -1,0 +1,71 @@
+path   = require 'path'
+fs     = require 'fs'
+vows   = require 'vows'
+assert = require 'assert'
+
+if !fs.existsSync('./test/connection.json')
+  console.error "Create test/connection.json to run functional tests"
+
+else
+
+  # override decoders for these types
+  decoders =
+    boolean : (buffer) -> "boolean #{buffer}"
+    integer : (buffer) -> "integer #{buffer}"
+    numeric : (buffer) -> "numeric #{buffer}"
+    real    : (buffer) -> "real #{buffer}"
+    string  : (buffer) -> "string #{buffer}"
+
+  Vertica = require('../src/vertica')
+  preferences = JSON.parse fs.readFileSync('./test/connection.json')
+
+  # load custom decoders
+  preferences.decoders = decoders
+
+  connection = Vertica.connect preferences, (err) ->
+    if err
+      console.error "\n\n#{err}"
+      console.error "Please make sure that you credentials in test/connection.json are correct."
+      throw "Database connection required for functional tests."
+
+
+  # help function to run queries as a topic
+  query = (sql, callback) ->
+    connection.query(sql, callback)
+    undefined
+
+
+  vow = vows.describe('Query')
+
+  vow.addBatch
+    "Running a simple SELECT query":
+      topic: ->
+        sql = "SELECT CAST(9223372036854775807 as NUMERIC), 1, 1.1, 'String', TRUE, CAST(123 AS REAL), CAST('2012-1-1' as Date)"
+        query(sql, @callback)
+
+      "it should return fields": (err, resultset) ->
+        assert.equal resultset.fields.length, 7
+        assert.equal resultset.fields[0].type, "numeric"
+        assert.equal resultset.fields[1].type, "integer"
+        assert.equal resultset.fields[2].type, "numeric"
+        assert.equal resultset.fields[3].type, "string"
+        assert.equal resultset.fields[4].type, "boolean"
+        assert.equal resultset.fields[5].type, "real"
+        assert.equal resultset.fields[6].type, "date"
+
+      "it should return rows": (err, resultset) ->
+        assert.equal resultset.rows.length, 1
+
+        col1 = decoders.numeric '9223372036854775807'
+        col2 = decoders.integer '1'
+        col3 = decoders.numeric '1.1'
+        col4 = decoders.string 'String'
+        col5 = decoders.boolean 't'
+        col6 = decoders.real '123'
+
+        # no custom decoder defined for this type
+        col7 = new Vertica.Date(2012, 1, 1)
+
+        assert.deepEqual resultset.rows[0], [col1, col2, col3, col4, col5, col6, col7], 'xxx'
+
+  vow.export(module)


### PR DESCRIPTION
Addresses this issue: https://github.com/wvanbergen/node-vertica/issues/12

connections options can have a decoders hash.
such as
  decoders =
    boolean : (buffer) -> "this guy decodes boolean field buffer"
    integer : (buffer) -> "this guy decodes integer field buffer"

Query passes the decoders to Query.Field, and Query.Field tries to find an appropriate decoder from the custom decoders first, otherwise falls back to the driver's own set of decoders.

This can be used easily to fix decoding behavior for 64bit or infinite precision numeric. The user will just have to substitute node-num or any other decoder to handle buffer deserialization.
