### PR TITLE
iojs support

### DIFF
--- a/lib/buffer.js
+++ b/lib/buffer.js
@@ -5,7 +5,7 @@ Buffer = require('buffer').Buffer;
 
 Buffer.prototype.writeZeroTerminatedString = function(str, offset, encoding) {
   var written;
-  written = this.write(str, offset, null, encoding);
+  written = this.write(str, offset, encoding);
   this.writeUInt8(0, offset + written);
   return written + 1;
 };

--- a/src/buffer.coffee
+++ b/src/buffer.coffee
@@ -1,7 +1,7 @@
 Buffer = require('buffer').Buffer
 
 Buffer::writeZeroTerminatedString = (str, offset, encoding) ->
-  written = @write(str, offset, null, encoding)
+  written = @write(str, offset, encoding)
   @writeUInt8(0, offset + written)
   return written + 1
 


### PR DESCRIPTION
Dont set buffer length explicitly to ```null```. Setting it to ```null``` causes some versions of node & iojs to interpret it as ```0```, causing buffer to be truncated. This closes https://github.com/wvanbergen/node-vertica/issues/36