### PR TITLE
Remove unnecessary 'require' in the timestamp decoder

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -114,7 +114,6 @@ exports.Time = VerticaTime;
 VerticaTimestamp = {
   fromStringBuffer: function(buffer) {
     var matches, timestampRegexp, timezoneOffset, utc;
-    timezoneOffset = require('./vertica');
     timestampRegexp = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?(?:([\+\-])(\d{2})(?:\:(\d{2}))?)?$/;
     if (matches = buffer.toString('ascii').match(timestampRegexp)) {
       utc = Date.UTC(+matches[1], +matches[2] - 1, +matches[3], +matches[4], +matches[5], +matches[6], Math.round(+matches[7] * 1000) || 0);

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     }
   ],
   "devDependencies": {
-    "coffee-script": "~> 1.9",
+    "coffee-script": "1.9.0",
     "mocha": "~> 1.18.0",
     "semver": "~> 2.2"
   },

--- a/src/types.coffee
+++ b/src/types.coffee
@@ -88,7 +88,6 @@ exports.Time = VerticaTime
 VerticaTimestamp =
 
   fromStringBuffer: (buffer) ->
-    timezoneOffset = require('./vertica')
     timestampRegexp = /^(\d{4})-(\d{2})-(\d{2}) (\d{2}):(\d{2}):(\d{2})(\.\d{1,})?(?:([\+\-])(\d{2})(?:\:(\d{2}))?)?$/
     if matches = buffer.toString('ascii').match(timestampRegexp)
       utc = Date.UTC(+matches[1], +matches[2] - 1, +matches[3], +matches[4], +matches[5], +matches[6], Math.round(+matches[7] * 1000) || 0)


### PR DESCRIPTION
The commit 5eae85a changed the way the timezoneOffset was handled
and this require appears to have been an artifact of that change.

Instead of being an export from the vertica module, it is handled
directly by VerticaTimestamp.setTimezoneOffset().

Calling require() repeatly still hits filepath related code, even if
cached. That can be expensive.